### PR TITLE
CSRF Attack

### DIFF
--- a/client-frontend/src/context/AuthContext.jsx
+++ b/client-frontend/src/context/AuthContext.jsx
@@ -14,11 +14,14 @@ import Login from '../pages/Login';
 const AuthContext = createContext({});
 
 const tokenRef = createRef();
+const csrfRef = createRef();
 
 export function AuthProvider({ authService, authErrorEventBus, children }) {
   const [user, setUser] = useState(undefined);
+  const [csrfToken, setCsrfToken] = useState(undefined);
 
   useImperativeHandle(tokenRef, () => (user ? user.token : undefined));
+  useImperativeHandle(csrfRef, () => csrfToken);
 
   useEffect(() => {
     authErrorEventBus.listen((err) => {
@@ -26,6 +29,10 @@ export function AuthProvider({ authService, authErrorEventBus, children }) {
       setUser(undefined);
     });
   }, [authErrorEventBus]);
+
+  useEffect(() => {
+    authService.csrfToken().then(setCsrfToken).catch(console.error);
+  }, [authService]);
 
   useEffect(() => {
     authService.me().then(setUser).catch(console.error);
@@ -85,4 +92,5 @@ export class AuthErrorEventBus {
 
 export default AuthContext;
 export const fetchToken = () => tokenRef.current;
+export const fetchCsrfToken = () => csrfRef.current;
 export const useAuth = () => useContext(AuthContext);

--- a/client-frontend/src/index.js
+++ b/client-frontend/src/index.js
@@ -5,14 +5,22 @@ import App from './App';
 import AuthService from './service/auth';
 import TweetService from './service/tweet';
 import { BrowserRouter } from 'react-router-dom';
-import { AuthProvider, fetchToken } from './context/AuthContext';
+import {
+  AuthProvider,
+  fetchToken,
+  fetchCsrfToken,
+} from './context/AuthContext';
 import { AuthErrorEventBus } from './context/AuthContext';
 import HttpClient from './network/http';
 import Socket from './network/socket';
 
 const baseURL = process.env.REACT_APP_BASE_URL;
 const authErrorEventBus = new AuthErrorEventBus();
-const httpClient = new HttpClient(baseURL, authErrorEventBus, ()=> fetchToken);
+const httpClient = new HttpClient(
+  baseURL,
+  authErrorEventBus, //
+  () => fetchCsrfToken()
+);
 const authService = new AuthService(httpClient);
 const socketClient = new Socket(baseURL, () => fetchToken());
 const tweetService = new TweetService(httpClient, socketClient);

--- a/client-frontend/src/index.js
+++ b/client-frontend/src/index.js
@@ -12,7 +12,7 @@ import Socket from './network/socket';
 
 const baseURL = process.env.REACT_APP_BASE_URL;
 const authErrorEventBus = new AuthErrorEventBus();
-const httpClient = new HttpClient(baseURL, authErrorEventBus);
+const httpClient = new HttpClient(baseURL, authErrorEventBus, ()=> fetchToken);
 const authService = new AuthService(httpClient);
 const socketClient = new Socket(baseURL, () => fetchToken());
 const tweetService = new TweetService(httpClient, socketClient);

--- a/client-frontend/src/network/http-fetch.js
+++ b/client-frontend/src/network/http-fetch.js
@@ -1,0 +1,37 @@
+export default class HttpClient {
+  constructor(baseURL, authErrorEventBus, getCsrfToken) {
+    this.baseURL = baseURL;
+    this.authErrorEventBus = authErrorEventBus;
+    this.getCsrfToken = getCsrfToken;
+  }
+
+  async fetch(url, options) {
+    const res = await fetch(`${this.baseURL}${url}`, {
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        ...options.headers,
+        '_csrf-token' : this.getCsrfToken(),
+      },
+      credentials: 'include',
+    });
+    let data;
+    try {
+      data = await res.json();
+    } catch (error) {
+      console.error(error);
+    }
+
+    if (res.status > 299 || res.status < 200) {
+      const message =
+        data && data.message ? data.message : 'Something went wrong! 🤪';
+      const error = new Error(message);
+      if (res.status === 401) {
+        this.authErrorEventBus.notify(error);
+        return;
+      }
+      throw error;
+    }
+    return data;
+  }
+}

--- a/client-frontend/src/network/http.js
+++ b/client-frontend/src/network/http.js
@@ -1,37 +1,61 @@
+import axios from 'axios';
+import axiosRetry from 'axios-retry';
+
+const defaultRetryConfig = {
+  retries: 5,
+  initialDelayMs: 100,
+};
+
 export default class HttpClient {
-  constructor(baseURL, authErrorEventBus) {
-    this.baseURL = baseURL;
+  constructor(
+    baseURL,
+    authErrorEventBus,
+    getCsrfToken,
+    config = defaultRetryConfig
+  ) {
     this.authErrorEventBus = authErrorEventBus;
-    this.getCsrfToken = this.getCsrfToken;
+    this.getCsrfToken = getCsrfToken;
+    this.client = axios.create({
+      baseURL: baseURL,
+      headers: { 'Content-Type': 'application/json' },
+      withCredentials: true,
+    });
+    axiosRetry(this.client, {
+      retries: config.retries,
+      retryDelay: (retry) => {
+        const delay = Math.pow(2, retry) * config.initialDelayMs; // 100, 200, 400, 800, 1600
+        const jitter = delay * 0.1 * Math.random(); // 10, 20, .... 160
+        return delay + jitter;
+      },
+      retryCondition: (err) =>
+        axiosRetry.isNetworkOrIdempotentRequestError(err) ||
+        err.response.status === 429,
+    });
   }
 
   async fetch(url, options) {
-    const res = await fetch(`${this.baseURL}${url}`, {
-      ...options,
+    const { body, method, headers } = options;
+    const req = {
+      url,
+      method,
       headers: {
-        'Content-Type': 'application/json',
-        ...options.headers,
-        '_csrf-token' : this.getCsrfToken(),
+        ...headers,
+        '_csrf-token': this.getCsrfToken(),
       },
-      credentials: 'include',
-    });
-    let data;
-    try {
-      data = await res.json();
-    } catch (error) {
-      console.error(error);
-    }
+      data: body,
+    };
 
-    if (res.status > 299 || res.status < 200) {
-      const message =
-        data && data.message ? data.message : 'Something went wrong! 🤪';
-      const error = new Error(message);
-      if (res.status === 401) {
-        this.authErrorEventBus.notify(error);
-        return;
+    try {
+      const res = await this.client(req);
+      return res.data;
+    } catch (err) {
+      if (err.response) {
+        const data = err.response.data;
+        const message =
+          data && data.message ? data.message : 'Something went wrong! 🤪';
+        throw new Error(message);
       }
-      throw error;
+      throw new Error('connection error');
     }
-    return data;
   }
 }

--- a/client-frontend/src/network/http.js
+++ b/client-frontend/src/network/http.js
@@ -2,6 +2,7 @@ export default class HttpClient {
   constructor(baseURL, authErrorEventBus) {
     this.baseURL = baseURL;
     this.authErrorEventBus = authErrorEventBus;
+    this.getCsrfToken = this.getCsrfToken;
   }
 
   async fetch(url, options) {
@@ -10,6 +11,7 @@ export default class HttpClient {
       headers: {
         'Content-Type': 'application/json',
         ...options.headers,
+        '_csrf-token' : this.getCsrfToken(),
       },
       credentials: 'include',
     });

--- a/client-frontend/src/service/auth.js
+++ b/client-frontend/src/service/auth.js
@@ -34,4 +34,11 @@ export default class AuthService {
       method: 'POST',
     });
   }
+
+  async csrfToken(){
+    const resp = await this.http.fetch('/auth/csrf-token', {
+      method: 'GET',
+    });
+    return resp.csrfToken;
+  }
 }

--- a/server-backend/app.js
+++ b/server-backend/app.js
@@ -12,6 +12,7 @@ import authRouter from './router/auth.js'
 import { config } from './config.js';
 import { initSocket } from './connection/socket.js';
 import { sequelize } from './db/database.js'
+import { csrfCheck } from './middleware/csrf.js';
 
 //console.log(process.env)
 const app = express();
@@ -28,7 +29,7 @@ app.use(helmet());
 app.use(cors(corsOption));
 app.use(morgan('tiny'));
 
-
+app.use(csrfCheck);
 app.use('/tweets', tweetsRouter); // "/tweets"로 접속했을 때 tweetsRoute로 연결
 app.use('/auth', authRouter);
 

--- a/server-backend/config.js
+++ b/server-backend/config.js
@@ -29,4 +29,7 @@ export const config = {
     cors: {
         allowedOrigin: required('CORS_ALLOW_ORIGIN'),
     },
+    csrf: {
+        plainToken: required('CSRF_SECRET_KEY'),
+    }
 };

--- a/server-backend/controller/auth.js
+++ b/server-backend/controller/auth.js
@@ -3,7 +3,6 @@ import bcrypt from "bcrypt";
 import {} from "express-async-errors";
 import * as userRepository from "../data/auth.js";
 import { config } from "../config.js";
-import { generate } from "fastify-cli/generate.js";
 
 function createJwtToken(id) {
   return jwt.sign({ id }, config.jwt.secretKey, {

--- a/server-backend/controller/auth.js
+++ b/server-backend/controller/auth.js
@@ -3,6 +3,7 @@ import bcrypt from "bcrypt";
 import {} from "express-async-errors";
 import * as userRepository from "../data/auth.js";
 import { config } from "../config.js";
+import { generate } from "fastify-cli/generate.js";
 
 function createJwtToken(id) {
   return jwt.sign({ id }, config.jwt.secretKey, {
@@ -65,4 +66,13 @@ export async function me(req, res, next) {
     return res.status(404).json({ message: "User not found" });
   }
   res.status(200).json({ token: req.token, username: user.username });
+}
+
+export async function csrfToken (req, res, next) {
+  const csrfToken = await generateCSRFToken();
+  res.status(200).json({ csrfToken });
+}
+
+export function generateCSRFToken() {
+  return bcrypt.hash(config.csrf.plainToken, 1); //한자리의 랜덤한 해쉬코드를 만들기 위해 1을 넣음
 }

--- a/server-backend/middleware/csrf.js
+++ b/server-backend/middleware/csrf.js
@@ -1,0 +1,1 @@
+import { config } from '../config.js'

--- a/server-backend/middleware/csrf.js
+++ b/server-backend/middleware/csrf.js
@@ -1,39 +1,37 @@
-import { config } from "../config.js";
-import bcrypt from "bcrypt";
+import { config } from '../config.js';
+import bcrypt from 'bcrypt';
 
 export const csrfCheck = (req, res, next) => {
-  //변경하는 API가 아니기 때문에 넘어감
   if (
-    req.method === "GET" ||
-    req.method === "OPTIONS" ||
-    req.method === "HEAD"
+    req.method === 'GET' ||
+    req.method === 'OPTIONS' ||
+    req.method === 'HEAD'
   ) {
     return next();
   }
 
-  //서버의 상태를 변경하는 API에 한에서 검사
-  const csrfHeader = req.get("_csrf-token");
+  const csrfHeader = req.get('_csrf-token');
 
   if (!csrfHeader) {
-    console.warn('Missing required " _csrf-token" header.', req.headers.origin); //서버에 기록남기는 용도
-    return res.status(403).json({ mssage: "Failed CSRF check" });
+    console.warn('Missing required "_csrf-token" header.', req.headers.origin);
+    return res.status(403).json({ message: 'Failed CSRF check' });
   }
 
   validateCsrfToken(csrfHeader)
     .then((valid) => {
       if (!valid) {
         console.warn(
-          'Value provided in "_vsrf-token" header does not validate',
+          'Value provided in "_csrf-token" header does not validate.',
           req.headers.origin,
           csrfHeader
         );
-        return res.status(403).json({ messgae: "Faild CSRF check" });
+        return res.status(403).json({ message: 'Failed CSRF check' });
       }
       next();
     })
     .catch((err) => {
       console.log(err);
-      return res.status(500).json({ message: "Somthing went worng" });
+      return res.status(500).json({ message: 'Something went wrong' });
     });
 };
 

--- a/server-backend/middleware/csrf.js
+++ b/server-backend/middleware/csrf.js
@@ -1,1 +1,42 @@
-import { config } from '../config.js'
+import { config } from "../config.js";
+import bcrypt from "bcrypt";
+
+export const csrfCheck = (req, res, next) => {
+  //변경하는 API가 아니기 때문에 넘어감
+  if (
+    req.method === "GET" ||
+    req.method === "OPTIONS" ||
+    req.method === "HEAD"
+  ) {
+    return next();
+  }
+
+  //서버의 상태를 변경하는 API에 한에서 검사
+  const csrfHeader = req.get("_csrf-token");
+
+  if (!csrfHeader) {
+    console.warn('Missing required " _csrf-token" header.', req.headers.origin); //서버에 기록남기는 용도
+    return res.status(403).json({ mssage: "Failed CSRF check" });
+  }
+
+  validateCsrfToken(csrfHeader)
+    .then((valid) => {
+      if (!valid) {
+        console.warn(
+          'Value provided in "_vsrf-token" header does not validate',
+          req.headers.origin,
+          csrfHeader
+        );
+        return res.status(403).json({ messgae: "Faild CSRF check" });
+      }
+      next();
+    })
+    .catch((err) => {
+      console.log(err);
+      return res.status(500).json({ message: "Somthing went worng" });
+    });
+};
+
+async function validateCsrfToken(csrfHeader) {
+  return bcrypt.compare(config.csrf.plainToken, csrfHeader);
+}

--- a/server-backend/router/auth.js
+++ b/server-backend/router/auth.js
@@ -37,4 +37,6 @@ router.post('/logout', authController.logout);
 
 router.get('/me', isAuth, authController.me); //로그인을 한 다음 유요한지 안한지를 확인하는 API
 
+router.get('/csrf-token', authController.csrfToken)
+
 export default router;

--- a/server-backend/router/auth.js
+++ b/server-backend/router/auth.js
@@ -37,6 +37,6 @@ router.post('/logout', authController.logout);
 
 router.get('/me', isAuth, authController.me); //로그인을 한 다음 유요한지 안한지를 확인하는 API
 
-router.get('/csrf-token', authController.csrfToken)
+router.get('/csrf-token', authController.csrfToken);
 
 export default router;


### PR DESCRIPTION
Cross-Site Request Forgery : authenticated된 사용자가 원하지 않는 action을 하도록 만드는 공격. 

문제 : local storage나 cookie에 저장된 데이터를 해커가 자바스크립트를 이용해 해커가 읽어갈 수 있음.


해결 logic
1. client가 server에게 CsrfToken 요청
2. server로 부터 CSRF token을 받음 
3. csrf_token을 이용해 server -> DB login요청
4. client는 HTTP Only Cookie: token=JWT 와 csrf_token을 application 메모리 상에 보관
5. 이후 client 요청때 JWT토큰을 HTTP Only옵션을 cookie로도 보내고, csrf_token을 Header에 붙임으로써 CSRF Attack을 예방.

결과
request를 한다고 해서 브라우저에 있는 HTTP Only cookie를 세션 라이딩을 한다고 해도 csrf_token이 있어야 함으로, application에서 발행받은 csrf_token을 이용해 CSRF Attack의 취약점을 보완할 수 있다.